### PR TITLE
Simplify conditional.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
 export default function (string) {
-    if(string.indexOf('-') === -1) {
-      return true;
-    } else {
-      return false;
-    }
+    return string.indexOf('-') === -1;
 }


### PR DESCRIPTION
We can simplify this by simply returning the result of the conditional.
We don't need to return `true` if it is `true` and `false` if it is `false`.